### PR TITLE
Rescue out-of-range dates

### DIFF
--- a/lib/epubinfo/models/date.rb
+++ b/lib/epubinfo/models/date.rb
@@ -12,7 +12,7 @@ module EPUBInfo
 
       # Should never be called directly, go through EPUBInfo.get
       def initialize(node)
-        self.time = Time.parse(node.content)
+        self.time = Time.parse(node.content) rescue nil
         self.event = node.attribute('event').content rescue nil
       end
 


### PR DESCRIPTION
### Welcome to the world's smallest pull request!

I experienced trouble when parsing _The Metamorphosis_ by Franz Kafka because the metadata contained a date value of `1912` which can't be parsed by `Time#parse` as it's out of range. This pull request will make it fall back to a nil value if an error occurs when parsing dates. 
