### PR TITLE
support modified date in EPUB3 meta element

### DIFF
--- a/lib/epubinfo/models/book.rb
+++ b/lib/epubinfo/models/book.rb
@@ -80,6 +80,12 @@ module EPUBInfo
         self.publisher = metadata.xpath('.//publisher').first.content rescue nil
         self.contributors = metadata.xpath('.//contributor').map {|c| EPUBInfo::Models::Person.new(c) }
         self.dates = metadata.xpath('.//date').map { |d| EPUBInfo::Models::Date.new(d) }
+        modified_date = metadata.xpath(".//meta[@property='dcterms:modified']").map do |d|
+          date = EPUBInfo::Models::Date.new(d)
+          date.event = 'modification'
+          date
+        end
+        self.dates += modified_date;
         self.identifiers = metadata.xpath('.//identifier').map { |i| EPUBInfo::Models::Identifier.new(i) }
         self.source = metadata.xpath('.//source').first.content rescue nil
         self.languages = metadata.xpath('.//language').map(&:content)

--- a/spec/lib/epubinfo/models/book_spec.rb
+++ b/spec/lib/epubinfo/models/book_spec.rb
@@ -103,8 +103,8 @@ describe EPUBInfo::Models::Book do
       end
 
       context 'dates' do
-        it 'count is 1' do
-          subject.dates.count.should == 1
+        it 'count is 2' do
+          subject.dates.count.should == 2
         end
       end
 


### PR DESCRIPTION
In http://idpf.org/epub/30/spec/epub30-publications.html#sec-meta-elem,

```
"the metadata element must contain exactly one meta element
 defining a [DCTERMS] modified property for the Publication."
```

I'm not sure whether 'event' value should be "modification" or "modified" (I use "modification" which is used in EPUB2).
