### PR TITLE
fix epub_cover_item search

### DIFF
--- a/lib/epubinfo/models/cover.rb
+++ b/lib/epubinfo/models/cover.rb
@@ -79,8 +79,9 @@ module EPUBInfo
 
           manifest = @parser.metadata_document.css('manifest')
 
-          manifest.css("item [id = #{cover_id}]").first rescue nil ||
-            manifest.css("item [property = #{cover_id}]").first rescue nil
+          (manifest.css("item [id = #{cover_id}]").first rescue nil) ||
+            (manifest.css("item [properties = #{cover_id}]").first rescue nil) ||
+            (manifest.css("item [property = #{cover_id}]").first rescue nil)
         end
       end
 


### PR DESCRIPTION
In EPUB 3, the item element has properties, not property.
http://idpf.org/epub/30/spec/epub30-publications.html#sec-item-elem

I'm not sure whether property is used or not, so I just add "item [properties = #{cover_id}]", not replace "item [property = #{cover_id}]".
